### PR TITLE
Adding script tags for abort fetch snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,14 +789,13 @@ const reduceRightArray = arr.reduceRight((acc, current) => {
 **[⬆ Back to Top](#table-of-contents)**
 ### Abort Fetch
 
-```javascript
-
-
-//HTML
+```html
+//html
 <button id="download">Download</button>
-<button id="abort">Abort</button>
+ <button id="abort">Abort</button>
 
 //JS
+<script type="text/javascript">
 let controller;
 
 document.querySelector('#download').addEventListener('click', () => {
@@ -809,7 +808,7 @@ document.querySelector('#download').addEventListener('click', () => {
 document.querySelector('#abort').addEventListener('click', function() {
   controller.abort();
 });
-
+</script>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -792,7 +792,7 @@ const reduceRightArray = arr.reduceRight((acc, current) => {
 ```html
 //html
 <button id="download">Download</button>
- <button id="abort">Abort</button>
+<button id="abort">Abort</button>
 
 //JS
 <script type="text/javascript">


### PR DESCRIPTION
* This pull request adds script tags in the [abort fetch snippet](https://github.com/JSsnippets/JavaScript-snippets#abort-fetch)

**Why?**

Since this is vanilla JS you can put it under `<script></script>` tags, so that it's easier to understand what's going on. Moreover the syntax highlight for the html snippet breaks due to the syntax highlight being configured to javascript. Keeping the syntax highlight to html keeps the highlight for html and javascript intact.